### PR TITLE
Make tests quieter by default

### DIFF
--- a/t/meta_fields.t
+++ b/t/meta_fields.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use Test::More;
-use Data::Dumper;
 
 use lib 't/lib';
 
@@ -25,7 +24,7 @@ my $expected =  [
    { 'name' => 'jetsam', source => 'Test::FormRole' },
 ];
 
-diag(Dumper(\@meta_fields));
+note(explain(\@meta_fields));
 
 is_deeply( \@meta_fields, $expected, 'got the meta fields we expected' );
 


### PR DESCRIPTION
Test::More has supported note() since 0.81_01 and dist.ini requires at
least 0.94.  Also, use Test::More's built-in explain() instead of
loading Data::Dumper.